### PR TITLE
add issue and pr templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug Report
+about: Create a report to help us improve.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is.-->
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+**Output**
+<!-- Copy/pasting the output is preferred, even for large error messages-->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen.-->
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,12 @@ assignees: ''
 <!-- A clear and concise description of what the bug is.-->
 
 **To Reproduce**
-Steps to reproduce the behavior:
+Steps to reproduce the behavior (ideally a [minimally reproducible example](https://stackoverflow.com/help/minimal-reproducible-example)):
+
+**Software versions**
+  - Which operating system and version did you use? (e.g. ubuntu 22.04.5)
+  - Which method did you use to install this package? (e.g. conda-forge)
+  - Copy/paste the output of `conda list` (or the equivalent for your package manager):
 
 **Output**
 <!-- Copy/pasting the output is preferred, even for large error messages-->

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest an idea for this project.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]-->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen.-->
+
+**Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions, workarounds, or features you've considered.-->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,16 @@
+<!--
+Thank you for pull request.
+Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
+-->
+
+<!--
+Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
+-->
+
+
+## Checklist
+* [ ] Added a ``news`` entry
+<!-- see https://regro.github.io/rever-docs/news.html for details on how to add news entry (you do not need to run the rever command) -->
+
+## Developers certificate of origin
+- [ ] I certify that this contribution is covered by the MIT License [here](https://github.com/OpenFreeEnergy/openfe/blob/main/LICENSE) and the **Developer Certificate of Origin** at <https://developercertificate.org/>.


### PR DESCRIPTION
These will become our project-wide default templates. We can override this behavior with any repo-specific templates.

see [here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for details